### PR TITLE
Changes Dev to Staging in CI workflow and scripts

### DIFF
--- a/.github/workflows/CreateImage.yml
+++ b/.github/workflows/CreateImage.yml
@@ -16,7 +16,7 @@ on:
 env:
   AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
   AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-  DEV_INSTANCE_ID: 'i-0a196b4cdcbc3ed7e'
+  STAGING_INSTANCE_ID: 'i-0a196b4cdcbc3ed7e'
 
 jobs:
   create_image:
@@ -34,12 +34,12 @@ jobs:
         working-directory: ./ci_scripts
         run: python create_ami.py
 
-      - name: Stop dev server
+      - name: Stop Staging Server
         if: always()
         working-directory: ./ci_scripts
-        run: python stop_dev_server.py
+        run: python stop_staging_server.py
     
-  stop_dev_server:
+  stop_staging_server:
     # this job will only run if the PR has been closed without being merged
     if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
@@ -51,6 +51,6 @@ jobs:
       - name: Install boto3
         run: pip install boto3
 
-      - name: Stop dev server
+      - name: Stop Staging Server
         working-directory: ./ci_scripts
-        run: python stop_dev_server.py
+        run: python stop_staging_server.py

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -20,14 +20,14 @@ env:
   DEBUG: 'False'
   SONG_ORDER: '5,3,1,0,2,4'
   SECRET_KEY: ${{secrets.SECRET_KEY}}
-  DEV_INSTANCE_ID: 'i-0a196b4cdcbc3ed7e'
+  STAGING_INSTANCE_ID: 'i-0a196b4cdcbc3ed7e'
   
 permissions:
   contents: read
   pull-requests: read
 
 jobs:
-  start_dev_server:
+  start_staging_server:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -36,10 +36,10 @@ jobs:
       - name: Install boto3
         run: pip install boto3
 
-      - name: Start Development Server
-        id: start_dev_server
+      - name: Start Staging Server
+        id: start_staging_server
         working-directory: ./ci_scripts
-        run: python start_dev_server.py
+        run: python start_staging_server.py
 
   pylint:
     runs-on: ubuntu-latest
@@ -79,10 +79,10 @@ jobs:
       - name: Run Unit Tests
         run: python manage.py test player
 
-      - name: Stop dev server
+      - name: Stop Staging Server
         if: ${{ failure()}}
         working-directory: ./ci_scripts
-        run: python stop_dev_server.py
+        run: python stop_staging_server.py
 
   build_docker_image:
     needs: [pylint, unit_tests]
@@ -106,15 +106,15 @@ jobs:
       - name: Push image to Docker Hub
         run: docker push krisaff84/lyria:$(date +'%Y-%m-%d') && docker push krisaff84/lyria:latest
 
-      - name: Stop dev server
+      - name: Stop Staging Server
         if: ${{ failure()}}
         working-directory: ./ci_scripts
         run: |
           pip install boto3
-          python stop_dev_server.py
+          python stop_staging_server.py
 
   pull_image_and_start_containers:
-    needs: [build_docker_image, start_dev_server]
+    needs: [build_docker_image, start_staging_server]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -123,18 +123,18 @@ jobs:
       - name: Install boto3
         run: pip install boto3
 
-      - name: Get Dev Server IP
-        id: get_dev_server_ip
+      - name: Get Stagint Server IP
+        id: get_staging_server_ip
         working-directory: ./ci_scripts
-        run: python get_dev_server_ip.py
+        run: python get_staging_server_ip.py
 
-      - name: Set environment variable for dev server IP
-        run: echo "DEV_SERVER_IP=${{ steps.get_dev_server_ip.outputs.public_ip }}" >> $GITHUB_ENV
+      - name: Set environment variable for staging server IP
+        run: echo "STAGING_SERVER_IP=${{ steps.get_staging_server_ip.outputs.public_ip }}" >> $GITHUB_ENV
 
       - name: Pull Docker image and start containers on instance
         uses: appleboy/ssh-action@master
         with:
-          host: ${{env.DEV_SERVER_IP}}
+          host: ${{env.STAGING_SERVER_IP}}
           username: ubuntu
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
           script: |
@@ -149,4 +149,8 @@ jobs:
             export SECRET_KEY=${{env.SECRET_KEY}}
             docker compose up -d
             unset SECRET_KEY
-
+      
+      - name: Stop Staging Server
+        if: ${{ failure()}}
+        working-directory: ./ci_scripts
+        run: python stop_staging_server.py

--- a/ci_scripts/create_ami.py
+++ b/ci_scripts/create_ami.py
@@ -8,7 +8,7 @@ import boto3
 
 access_key_id = os.environ.get('AWS_ACCESS_KEY_ID')
 secret_access_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
-instance_id = os.environ.get('DEV_INSTANCE_ID')
+instance_id = os.environ.get('STAGING_INSTANCE_ID')
 
 
 ec2 = boto3.client(

--- a/ci_scripts/get_staging_server_ip.py
+++ b/ci_scripts/get_staging_server_ip.py
@@ -5,7 +5,7 @@ import boto3
 
 access_key_id = os.environ.get('AWS_ACCESS_KEY_ID')
 secret_access_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
-instance_id = os.environ.get('DEV_INSTANCE_ID')
+instance_id = os.environ.get('STAGING_INSTANCE_ID')
 
 ec2 = boto3.client(
     'ec2',
@@ -21,6 +21,6 @@ response = ec2.describe_instances(InstanceIds=[instance_id])
 
 public_ip = response['Reservations'][0]['Instances'][0]['PublicIpAddress']
 
-print(f"Lyria Dev Instance is now running at: {public_ip}")
+print(f"Lyria Staging Instance is now running at: {public_ip}")
 with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
     output_file.write(f'public_ip={public_ip}\n')

--- a/ci_scripts/start_staging_server.py
+++ b/ci_scripts/start_staging_server.py
@@ -6,7 +6,7 @@ import boto3
 
 access_key_id = os.environ.get('AWS_ACCESS_KEY_ID')
 secret_access_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
-instance_id = os.environ.get('DEV_INSTANCE_ID')
+instance_id = os.environ.get('STAGING_INSTANCE_ID')
 
 ec2 = boto3.client(
     'ec2',

--- a/ci_scripts/stop_staging_server.py
+++ b/ci_scripts/stop_staging_server.py
@@ -6,7 +6,7 @@ import boto3
 
 access_key_id = os.environ.get('AWS_ACCESS_KEY_ID')
 secret_access_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
-instance_id = os.environ.get('DEV_INSTANCE_ID')
+instance_id = os.environ.get('STAGING_INSTANCE_ID')
 
 ec2 = boto3.client(
     'ec2',
@@ -20,4 +20,4 @@ response = ec2.stop_instances(
         instance_id,
     ]
 )
-print("Dev Server Stopped")
+print("Staging Server Stopped")


### PR DESCRIPTION
Previously, the instance in which the containers were deployed to and AMI built from was called the Dev Server. Given that it's more of a 'pre-production' environment, I've changed the name to Staging Server. This commit changes all variables and CI files that refer to the Dev Server to the Staging Server.