### PR TITLE
Adds step to RunContainers.yml to stop Containers

### DIFF
--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -131,6 +131,16 @@ jobs:
       - name: Set environment variable for staging server IP
         run: echo "STAGING_SERVER_IP=${{ steps.get_staging_server_ip.outputs.public_ip }}" >> $GITHUB_ENV
       
+      - name: Stop Previous Containers and Remove Images
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{env.STAGING_SERVER_IP}}
+          username: ubuntu
+          key: ${{secrets.LYRIA_PRIVATE_KEY}}
+          script: |
+            docker compose down
+            docker prune -f
+
       - name: Copy Files to Staging Server
         uses: appleboy/scp-action@master
         with:
@@ -148,8 +158,6 @@ jobs:
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
           script: |
             apt update && apt upgrade -y
-            docker compose down
-            docker prune -f
             export AWS_STORAGE_BUCKET_NAME=${{env.AWS_STORAGE_BUCKET_NAME}}
             export AWS_S3_REGION_NAME=${{env.AWS_S3_REGION_NAME}}
             export CLOUDFRONT_URL=${{env.CLOUDFRONT_URL}}


### PR DESCRIPTION
Previously, the compose file was copied to the staging server and then the older containers were stopped and images removed. This posed a problem where the new compose file could use a different tag for the containers, and then the old containers would not be removed. This commit fixes that issue.