### PR TITLE
CI:Changes compose file to use os environment vars

### DIFF
--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -138,6 +138,7 @@ jobs:
           username: ubuntu
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
           script: |
+            export SECRET_KEY=${{env.SECRET_KEY}}
             docker compose down
             docker prune -f
 
@@ -163,7 +164,6 @@ jobs:
             export CLOUDFRONT_URL=${{env.CLOUDFRONT_URL}}
             export DEBUG=${{env.DEBUG}}
             export SONG_ORDER=${{env.SONG_ORDER}}
-            export SECRET_KEY=${{env.SECRET_KEY}}
             docker compose up -d
             unset SECRET_KEY
       

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -138,9 +138,8 @@ jobs:
           username: ubuntu
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
           script: |
-            export SECRET_KEY=${{env.SECRET_KEY}}
             docker compose down
-            docker prune -f
+            docker system prune -f
 
       - name: Copy Files to Staging Server
         uses: appleboy/scp-action@master
@@ -164,6 +163,7 @@ jobs:
             export CLOUDFRONT_URL=${{env.CLOUDFRONT_URL}}
             export DEBUG=${{env.DEBUG}}
             export SONG_ORDER=${{env.SONG_ORDER}}
+            export SECRET_KEY=${{env.SECRET_KEY}}
             docker compose up -d
             unset SECRET_KEY
       

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -131,6 +131,16 @@ jobs:
       - name: Set environment variable for staging server IP
         run: echo "STAGING_SERVER_IP=${{ steps.get_staging_server_ip.outputs.public_ip }}" >> $GITHUB_ENV
       
+      - name: Stop Previous Containers and Remove Images
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{env.STAGING_SERVER_IP}}
+          username: ubuntu
+          key: ${{secrets.LYRIA_PRIVATE_KEY}}
+          script: |
+            docker compose down
+            docker prune -f
+
       - name: Copy Files to Staging Server
         uses: appleboy/scp-action@master
         with:
@@ -148,8 +158,6 @@ jobs:
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
           script: |
             apt update && apt upgrade -y
-            docker compose down
-            docker prune -f
             export AWS_STORAGE_BUCKET_NAME=${{env.AWS_STORAGE_BUCKET_NAME}}
             export AWS_S3_REGION_NAME=${{env.AWS_S3_REGION_NAME}}
             export CLOUDFRONT_URL=${{env.CLOUDFRONT_URL}}

--- a/compose.yml
+++ b/compose.yml
@@ -3,8 +3,14 @@ services:
     container_name: app
     image: krisaff84/lyria:latest
 
-    env_file:
-      - .env
+    environment:
+      AWS_STORAGE_BUCKET_NAME: ${AWS_STORAGE_BUCKET_NAME}
+      AWS_S3_REGION_NAME: ${AWS_S3_REGION_NAME}
+      CLOUDFRONT_URL: ${CLOUDFRONT_URL}
+      DEBUG: ${DEBUG}
+      SONG_ORDER: ${SONG_ORDER}
+      SECRET_KEY: ${SECRET_KEY}
+      
     networks:
       - backend
     restart: always


### PR DESCRIPTION
The compose file now uses os environment variables instead of a .env file. Additionally, there is a step to export the secret key before the docker compose down command, since the secret key was previously unset.