### PR TITLE
Reformats CI to use .env file for compose

### DIFF
--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -138,6 +138,7 @@ jobs:
           username: ubuntu
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
           script: |
+            export SECRET_KEY=${{env.SECRET_KEY}}
             docker compose down
             docker prune -f
 
@@ -163,7 +164,6 @@ jobs:
             export CLOUDFRONT_URL=${{env.CLOUDFRONT_URL}}
             export DEBUG=${{env.DEBUG}}
             export SONG_ORDER=${{env.SONG_ORDER}}
-            export SECRET_KEY=${{env.SECRET_KEY}}
             docker compose up -d
             unset SECRET_KEY
       

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -172,12 +172,12 @@ jobs:
                 SECRET_KEY
           script: |
             sudo apt update && sudo apt upgrade -y
-            export AWS_STORAGE_BUCKET_NAME=${AWS_STORAGE_BUCKET_NAME}
-            export AWS_S3_REGION_NAME=${AWS_S3_REGION_NAME}
-            export CLOUDFRONT_URL=${CLOUDFRONT_URL}
-            export DEBUG=${DEBUG}
-            export SONG_ORDER=${SONG_ORDER}
-            export SECRET_KEY=${SECRET_KEY}
+            export AWS_STORAGE_BUCKET_NAME=$AWS_STORAGE_BUCKET_NAME
+            export AWS_S3_REGION_NAME=$AWS_S3_REGION_NAME
+            export CLOUDFRONT_URL=$CLOUDFRONT_URL
+            export DEBUG=$DEBUG
+            export SONG_ORDER=$SONG_ORDER
+            export SECRET_KEY=$SECRET_KEY
             sudo docker compose up -d
             unset SECRET_KEY
       

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -138,9 +138,8 @@ jobs:
           username: ubuntu
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
           script: |
-            export SECRET_KEY=${{env.SECRET_KEY}}
             docker compose down
-            docker prune -f
+            docker system prune -f
 
       - name: Copy Files to Staging Server
         uses: appleboy/scp-action@master
@@ -164,6 +163,7 @@ jobs:
             export CLOUDFRONT_URL=${{env.CLOUDFRONT_URL}}
             export DEBUG=${{env.DEBUG}}
             export SONG_ORDER=${{env.SONG_ORDER}}
+            export SECRET_KEY=${{env.SECRET_KEY}}
             docker compose up -d
             unset SECRET_KEY
       

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -147,14 +147,14 @@ jobs:
           username: ubuntu
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
           script: |
-            apt update && apt upgrade -y
+            sudo apt update && sudo apt upgrade -y
             export AWS_STORAGE_BUCKET_NAME=${{env.AWS_STORAGE_BUCKET_NAME}}
             export AWS_S3_REGION_NAME=${{env.AWS_S3_REGION_NAME}}
             export CLOUDFRONT_URL=${{env.CLOUDFRONT_URL}}
             export DEBUG=${{env.DEBUG}}
             export SONG_ORDER=${{env.SONG_ORDER}}
             export SECRET_KEY=${{env.SECRET_KEY}}
-            docker compose up -d
+            sudo docker compose up -d
             unset SECRET_KEY
       
       - name: Stop Staging Server

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -153,18 +153,25 @@ jobs:
 
       - name: Pull Docker Image and Start Containers on Staging Server
         uses: appleboy/ssh-action@master
+        env:
+          AWS_STORAGE_BUCKET_NAME: ${{ env.AWS_STORAGE_BUCKET_NAME }}
+          AWS_S3_REGION_NAME: ${{ env.AWS_S3_REGION_NAME }}
+          CLOUDFRONT_URL: ${{ env.CLOUDFRONT_URL }}
+          DEBUG: ${{ env.DEBUG }}
+          SONG_ORDER: ${{ env.SONG_ORDER }}
+          SECRET_KEY: ${{ env.SECRET_KEY }}
         with:
           host: ${{env.STAGING_SERVER_IP}}
           username: ubuntu
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
+          envs: AWS_STORAGE_BUCKET_NAME,
+                AWS_S3_REGION_NAME,
+                CLOUDFRONT_URL,
+                DEBUG,
+                SONG_ORDER,
+                SECRET_KEY
           script: |
             sudo apt update && sudo apt upgrade -y
-            export AWS_STORAGE_BUCKET_NAME=${{env.AWS_STORAGE_BUCKET_NAME}}
-            export AWS_S3_REGION_NAME=${{env.AWS_S3_REGION_NAME}}
-            export CLOUDFRONT_URL=${{env.CLOUDFRONT_URL}}
-            export DEBUG=${{env.DEBUG}}
-            export SONG_ORDER=${{env.SONG_ORDER}}
-            export SECRET_KEY=${{env.SECRET_KEY}}
             sudo docker compose up -d
             unset SECRET_KEY
       

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -130,16 +130,6 @@ jobs:
 
       - name: Set environment variable for staging server IP
         run: echo "STAGING_SERVER_IP=${{ steps.get_staging_server_ip.outputs.public_ip }}" >> $GITHUB_ENV
-      
-      - name: Stop Previous Containers and Remove Images
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{env.STAGING_SERVER_IP}}
-          username: ubuntu
-          key: ${{secrets.LYRIA_PRIVATE_KEY}}
-          script: |
-            docker compose down
-            docker system prune -f
 
       - name: Copy Files to Staging Server
         uses: appleboy/scp-action@master

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -131,6 +131,17 @@ jobs:
       - name: Set environment variable for staging server IP
         run: echo "STAGING_SERVER_IP=${{ steps.get_staging_server_ip.outputs.public_ip }}" >> $GITHUB_ENV
 
+      - name: Stop Previous Containers and Remove Images
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{env.STAGING_SERVER_IP}}
+          username: ubuntu
+          key: ${{secrets.LYRIA_PRIVATE_KEY}}
+          script: |
+            sudo docker compose down
+            sudo docker system prune --all --force
+
+
       - name: Copy Files to Staging Server
         uses: appleboy/scp-action@master
         with:

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -164,12 +164,7 @@ jobs:
           host: ${{env.STAGING_SERVER_IP}}
           username: ubuntu
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
-          envs: AWS_STORAGE_BUCKET_NAME,
-                AWS_S3_REGION_NAME,
-                CLOUDFRONT_URL,
-                DEBUG,
-                SONG_ORDER,
-                SECRET_KEY
+          envs: AWS_STORAGE_BUCKET_NAME,AWS_S3_REGION_NAME,CLOUDFRONT_URL,DEBUG,SONG_ORDER,SECRET_KEY
           script: |
             sudo apt update && sudo apt upgrade -y
             export AWS_STORAGE_BUCKET_NAME=$AWS_STORAGE_BUCKET_NAME

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -131,6 +131,16 @@ jobs:
       - name: Set environment variable for staging server IP
         run: echo "STAGING_SERVER_IP=${{ steps.get_staging_server_ip.outputs.public_ip }}" >> $GITHUB_ENV
       
+      - name: Stop Previous Containers and Remove Images
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{env.STAGING_SERVER_IP}}
+          username: ubuntu
+          key: ${{secrets.LYRIA_PRIVATE_KEY}}
+          script: |
+            docker compose down
+            docker prune -f
+
       - name: Copy Files to Staging Server
         uses: appleboy/scp-action@master
         with:
@@ -148,8 +158,6 @@ jobs:
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
           script: |
             apt update && apt upgrade -y
-            docker compose down
-            docker prune -f
             export AWS_STORAGE_BUCKET_NAME=${{env.AWS_STORAGE_BUCKET_NAME}}
             export AWS_S3_REGION_NAME=${{env.AWS_S3_REGION_NAME}}
             export CLOUDFRONT_URL=${{env.CLOUDFRONT_URL}}

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -130,7 +130,11 @@ jobs:
 
       - name: Set environment variable for staging server IP
         run: echo "STAGING_SERVER_IP=${{ steps.get_staging_server_ip.outputs.public_ip }}" >> $GITHUB_ENV
-
+      
+      - name: Create .env File
+        working-directory: ./ci_scripts
+        run: python create_env.py
+        
       - name: Stop Previous Containers and Remove Images
         uses: appleboy/ssh-action@master
         with:
@@ -141,40 +145,25 @@ jobs:
             sudo docker compose down
             sudo docker system prune --all --force
 
-
       - name: Copy Files to Staging Server
         uses: appleboy/scp-action@master
         with:
           host: ${{env.STAGING_SERVER_IP}}
           username: ubuntu
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
-          source: 'compose.yml, nginx.conf'
+          source: 'compose.yml, nginx.conf, .env'
           target: '/home/ubuntu'
 
       - name: Pull Docker Image and Start Containers on Staging Server
         uses: appleboy/ssh-action@master
-        env:
-          AWS_STORAGE_BUCKET_NAME: ${{ env.AWS_STORAGE_BUCKET_NAME }}
-          AWS_S3_REGION_NAME: ${{ env.AWS_S3_REGION_NAME }}
-          CLOUDFRONT_URL: ${{ env.CLOUDFRONT_URL }}
-          DEBUG: ${{ env.DEBUG }}
-          SONG_ORDER: ${{ env.SONG_ORDER }}
-          SECRET_KEY: ${{ env.SECRET_KEY }}
         with:
           host: ${{env.STAGING_SERVER_IP}}
           username: ubuntu
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
-          envs: AWS_STORAGE_BUCKET_NAME,AWS_S3_REGION_NAME,CLOUDFRONT_URL,DEBUG,SONG_ORDER,SECRET_KEY
           script: |
             sudo apt update && sudo apt upgrade -y
-            export AWS_STORAGE_BUCKET_NAME=$AWS_STORAGE_BUCKET_NAME
-            export AWS_S3_REGION_NAME=$AWS_S3_REGION_NAME
-            export CLOUDFRONT_URL=$CLOUDFRONT_URL
-            export DEBUG=$DEBUG
-            export SONG_ORDER=$SONG_ORDER
-            export SECRET_KEY=$SECRET_KEY
             sudo docker compose up -d
-            unset SECRET_KEY
+            rm .env
       
       - name: Stop Staging Server
         if: ${{ failure()}}

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -172,6 +172,12 @@ jobs:
                 SECRET_KEY
           script: |
             sudo apt update && sudo apt upgrade -y
+            export AWS_STORAGE_BUCKET_NAME=${AWS_STORAGE_BUCKET_NAME}
+            export AWS_S3_REGION_NAME=${AWS_S3_REGION_NAME}
+            export CLOUDFRONT_URL=${CLOUDFRONT_URL}
+            export DEBUG=${DEBUG}
+            export SONG_ORDER=${SONG_ORDER}
+            export SECRET_KEY=${SECRET_KEY}
             sudo docker compose up -d
             unset SECRET_KEY
       

--- a/ci_scripts/create_env.py
+++ b/ci_scripts/create_env.py
@@ -1,0 +1,17 @@
+""" This script creates a .env file to copy to the staging server in the CI pipeline """
+
+import os
+
+env_file = '../.env'
+envs = {
+    'AWS_STORAGE_BUCKET_NAME': os.environ.get('AWS_STORAGE_BUCKET_NAME'),
+    'AWS_S3_REGION_NAME': os.environ.get('AWS_S3_REGION_NAME'),
+    'CLOUDFRONT_URL': os.environ.get('CLOUDFRONT_URL'),
+    'SECRET_KEY': f"'{os.environ.get('SECRET_KEY')}'",
+    'DEBUG': os.environ.get('DEBUG'),
+    'SONG_ORDER': os.environ.get('SONG_ORDER')
+}
+
+with open(env_file, 'x') as f:
+    for key, value in envs.items():
+        f.write(f'{key}={value}\n')

--- a/compose.yml
+++ b/compose.yml
@@ -3,8 +3,14 @@ services:
     container_name: app
     image: krisaff84/lyria:latest
 
-    env_file:
-      - .env
+    environment:
+      AWS_STORAGE_BUCKET_NAME: ${AWS_STORAGE_BUCKET_NAME}
+      AWS_S3_REGION_NAME: ${AWS_S3_REGION_NAME}
+      CLOUDFRONT_URL: ${CLOUDFRONT_URL}
+      DEBUG: ${DEBUG}
+      SONG_ORDER: ${SONG_ORDER}
+      SECRET_KEY: ${SECRET_KEY}
+      
     networks:
       - backend
     restart: always

--- a/compose.yml
+++ b/compose.yml
@@ -4,12 +4,12 @@ services:
     image: krisaff84/lyria:latest
 
     environment:
-      AWS_STORAGE_BUCKET_NAME: ${AWS_STORAGE_BUCKET_NAME}
-      AWS_S3_REGION_NAME: ${AWS_S3_REGION_NAME}
-      CLOUDFRONT_URL: ${CLOUDFRONT_URL}
-      DEBUG: ${DEBUG}
-      SONG_ORDER: ${SONG_ORDER}
-      SECRET_KEY: ${SECRET_KEY}
+      - AWS_STORAGE_BUCKET_NAME=${AWS_STORAGE_BUCKET_NAME}
+      - AWS_S3_REGION_NAME=${AWS_S3_REGION_NAME}
+      - CLOUDFRONT_URL=${CLOUDFRONT_URL}
+      - DEBUG=${DEBUG}
+      - SONG_ORDER=${SONG_ORDER}
+      - SECRET_KEY=${SECRET_KEY}
       
     networks:
       - backend

--- a/compose.yml
+++ b/compose.yml
@@ -3,13 +3,8 @@ services:
     container_name: app
     image: krisaff84/lyria:latest
 
-    environment:
-      - AWS_STORAGE_BUCKET_NAME=${AWS_STORAGE_BUCKET_NAME}
-      - AWS_S3_REGION_NAME=${AWS_S3_REGION_NAME}
-      - CLOUDFRONT_URL=${CLOUDFRONT_URL}
-      - DEBUG=${DEBUG}
-      - SONG_ORDER=${SONG_ORDER}
-      - SECRET_KEY=${SECRET_KEY}
+    env_file:
+      - .env
       
     networks:
       - backend


### PR DESCRIPTION
There was a problem with the compose file not recognizing environment variables when using the environment parameter. This change uses a python script (create_env.py) to create a .env file which is then removed after the compose file is run.