### PR TITLE
Adds DeregisterAmi workflow

### DIFF
--- a/.github/ci_scripts/deregister_ami.py
+++ b/.github/ci_scripts/deregister_ami.py
@@ -1,0 +1,70 @@
+""" This script deregisters either the oldest or most recent version of the Lyria
+    application AMI. It runs from the workflow file DeregisterAmi.yml, and an input
+    of either 'oldest' or 'latest' is provided.
+"""
+
+import boto3
+import sys
+import os
+
+
+access_key_id = os.environ.get('AWS_ACCESS_KEY_ID')
+secret_access_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
+aws_region = os.environ.get('AWS_REGION')
+ami_version = sys.argv[1]
+
+ec2 = boto3.client(
+    'ec2',
+    region_name='us-east-2',
+    aws_access_key_id=access_key_id,
+    aws_secret_access_key=secret_access_key  
+)
+
+response = ec2.describe_images(
+    Owners=['self'],
+    Filters=[
+        {
+            'Name': 'name',
+            'Values': [
+                'lyria_v*'
+            ]
+        }
+    ]
+)
+
+version_numbers = []
+for image in response['Images']:
+    version_number = image['Name'][::-1][0]
+    version_numbers.append(int(version_number))
+
+if ami_version == 'oldest':
+    ami_version_to_deregister = min(version_numbers)
+else:
+    ami_version_to_deregister = max(version_numbers)
+
+response = ec2.describe_images(
+    Owners=['self'],
+    Filters=[
+        {
+            'Name': 'name',
+            'Values': [
+                f'lyria_v{ami_version_to_deregister}'
+            ]
+        }
+    ]
+)
+
+ami_id = response['Images'][0]['ImageId']
+snapshot_id = response['Images'][0]['BlockDeviceMappings'][0]['Ebs']['SnapshotId']
+
+response = ec2.deregister_image(
+    ImageId=ami_id
+)
+
+print(f'AMI {ami_id} (version {ami_version_to_deregister}) deregistered successfully')
+
+response = ec2.delete_snapshot(
+    SnapshotId=snapshot_id
+)
+
+print(f'Snapshot {snapshot_id} (for AMI version {ami_version_to_deregister}) deleted successfully')

--- a/.github/workflows/DeregisterAmi.yml
+++ b/.github/workflows/DeregisterAmi.yml
@@ -1,0 +1,33 @@
+name: Deregister AMI
+on:
+    workflow_dispatch:
+        inputs:
+            ami_version:
+                description: 'Version of Lyria AMI to deregister'
+                required: true
+                type: choice
+                options:
+                    - oldest
+                    - latest
+env:
+    AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    AWS_REGION: 'us-east-2'
+
+
+jobs:
+    deregister-ami:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v4
+
+            - name: Install boto3
+              run: pip install boto3
+
+            - name: Deregister AMI
+              working-directory: .github/ci_scripts
+              run: python deregister_ami.py ${{ github.event.inputs.ami_version }}
+                  
+
+


### PR DESCRIPTION
Adds a workflow to be triggered manually that will deregister AMI and delete snapshot associated with it. Either the 'oldest' or 'latest' version of the Lyria AMI can be chosen. Additionally, adds workflow to push the current AMI to production, but nothing is actually in that file as of now.