### PR TITLE
Configure for IPv6

### DIFF
--- a/.github/ci_scripts/get_staging_server_ip.py
+++ b/.github/ci_scripts/get_staging_server_ip.py
@@ -5,7 +5,7 @@ import boto3
 
 access_key_id = os.environ.get('AWS_ACCESS_KEY_ID')
 secret_access_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
-instance_id = os.environ.get('STAGING_INSTANCE_ID')
+instance_id = 'i-01ee3032740fc3229'
 
 ec2 = boto3.client(
     'ec2',
@@ -19,8 +19,14 @@ waiter.wait(InstanceIds=[instance_id])
 
 response = ec2.describe_instances(InstanceIds=[instance_id])
 
-public_ip = response['Reservations'][0]['Instances'][0]['PublicIpAddress']
+if 'PublicIpAddress' in response['Reservations'][0]['Instances'][0]:
+    public_ip = response['Reservations'][0]['Instances'][0]['PublicIpAddress']
+    print(f"Lyria Staging Instance is now running at: {public_ip}")
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
+        output_file.write(f'public_ip={public_ip}\n')
+else:
+    ipv6_address = response['Reservations'][0]['Instances'][0]['NetworkInterfaces'][0]['Ipv6Addresses'][0]['Ipv6Address']
+    print(f"Lyria Staging Instance is now running at: {ipv6_address}")
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
+        output_file.write(f'public_ip={ipv6_address}\n')
 
-print(f"Lyria Staging Instance is now running at: {public_ip}")
-with open(os.environ['GITHUB_OUTPUT'], 'a') as output_file:
-    output_file.write(f'public_ip={public_ip}\n')

--- a/.github/workflows/CreateImage.yml
+++ b/.github/workflows/CreateImage.yml
@@ -15,7 +15,7 @@ on:
 env:
   AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
   AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-  STAGING_INSTANCE_ID: 'i-0a196b4cdcbc3ed7e'
+  STAGING_INSTANCE_ID: 'i-01ee3032740fc3229'
 
 jobs:
   create_image:

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -140,6 +140,7 @@ jobs:
           host: ${{env.STAGING_SERVER_IP}}
           username: ubuntu
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
+          protocol: 'tcp6'
           script: |
             touch .env
             sudo docker compose down
@@ -160,6 +161,7 @@ jobs:
           host: ${{env.STAGING_SERVER_IP}}
           username: ubuntu
           key: ${{secrets.LYRIA_PRIVATE_KEY}}
+          protocol: 'tcp6'
           script: |
             sudo apt update && sudo apt upgrade -y
             sudo docker compose up -d

--- a/.github/workflows/RunContainers.yml
+++ b/.github/workflows/RunContainers.yml
@@ -19,7 +19,7 @@ env:
   DEBUG: 'False'
   SONG_ORDER: '5,3,1,0,2,4'
   SECRET_KEY: ${{secrets.SECRET_KEY}}
-  STAGING_INSTANCE_ID: 'i-0a196b4cdcbc3ed7e'
+  STAGING_INSTANCE_ID: 'i-01ee3032740fc3229'
   
 permissions:
   contents: read

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,7 +1,7 @@
 # Install GUnicorn - pip install gunicorn
 # Run - gunicorn -c gunicorn.conf.py lyria.wsgi:application
 
-bind = "0.0.0.0:80"
+bind = "[::]:80"
 workers = 3
 timeout = 60
 module = "lyria.wsgi:application"

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,7 @@ events {
 http {
     server {
         listen 80;
+        listen [::]:80;
         server_name localhost;
 
         location / {


### PR DESCRIPTION
Updated gunicorn.config.py and nginx.conf to support IPv6. Also modified CI workflows and scripts to use new staging server in IPv6 VPC and subnet. 