### PR TITLE
Brings DNS records under Terrform management

### DIFF
--- a/terraform/dns_records/main.tf
+++ b/terraform/dns_records/main.tf
@@ -1,9 +1,19 @@
+provider "aws" {
+  region  = "us-east-2"
+  profile = "admin-profile"
+}
+
+
+#######################################
+# Records for ELB
+#######################################
+
 data "aws_lb" "current" {
   name = "${var.name_prefix}-elb"
 }
 resource "aws_route53_record" "main" {
-  zone_id = "Z09206903VMHX9SR3PGQF"
-  name    = "meettheafflerbaughs.com"
+  zone_id = var.zone_id_main
+  name    = var.A_record_name
   type    = "A"
 
   alias {
@@ -14,8 +24,8 @@ resource "aws_route53_record" "main" {
 }
 
 resource "aws_route53_record" "misspelled" {
-  zone_id = "Z06032811HZJPQ3EPMZ6P"
-  name    = "meetheafflerbaughs.com"
+  zone_id = var.zone_id_misspelled
+  name    = var.A_record_name_misspelled
   type    = "A"
 
   alias {
@@ -25,10 +35,33 @@ resource "aws_route53_record" "misspelled" {
   }
 }
 
+#######################################
+# Records for CloudFront to S3 origin
+#######################################
+
+resource "aws_route53_record" "cf_s3_origin_main" {
+  zone_id = var.zone_id_main
+  name    = var.cf_s3_origin_main_name
+  type    = "CNAME"
+  records = [var.cf_s3_origin_main_record]
+  ttl     = var.cf_s3_origin_ttl
+}
+
+resource "aws_route53_record" "cf_s3_origin_misspelled" {
+  zone_id = var.zone_id_misspelled
+  name    = var.cf_s3_origin_misspelled_name
+  type    = "CNAME"
+  records = [var.cf_s3_origin_misspelled_record]
+  ttl     = var.cf_s3_origin_ttl
+}
+
+#######################################
+# Outputs
+#######################################
+
 output "elb_dns" {
   value = data.aws_lb.current.dns_name
 }
 output "elb_zone_id" {
   value = data.aws_lb.current.zone_id
 }
-

--- a/terraform/dns_records/variables.tf
+++ b/terraform/dns_records/variables.tf
@@ -2,3 +2,48 @@ variable "name_prefix" {
   description = "Naming prefix of current elb"
   default     = "lyria-green"
 }
+
+variable "zone_id_main" {
+  description = "Route53 zone ID for main domain"
+  default     = "Z09206903VMHX9SR3PGQF"
+}
+
+variable "zone_id_misspelled" {
+  description = "Route53 zone ID for misspelled domain"
+  default     = "Z06032811HZJPQ3EPMZ6P"
+}
+
+variable "A_record_name" {
+  description = "Name of the A record"
+  default     = "meettheafflerbaughs.com"
+}
+
+variable "A_record_name_misspelled" {
+  description = "Name of the A record for the misspelled domain"
+  default     = "meetheafflerbaughs.com"
+}
+
+variable "cf_s3_origin_main_name" {
+  description = "Name of the CloudFront to S3 origin record for the main domain"
+  default     = "_7712d544302839ae72944da8902036a5.meettheafflerbaughs.com"
+}
+
+variable "cf_s3_origin_misspelled_name" {
+  description = "Name of the CloudFront to S3 origin record for the misspelled domain"
+  default     = "_a6cf547631e0295dbcb4dfb53dcb2d84.meetheafflerbaughs.com"
+}
+
+variable "cf_s3_origin_main_record" {
+  description = "Record for the CloudFront to S3 origin for the main domain"
+  default     = "_5eabf0c387b879db1720051c2e611680.mhbtsbpdnt.acm-validations.aws"
+}
+
+variable "cf_s3_origin_misspelled_record" {
+  description = "Record for the CloudFront to S3 origin for the misspelled domain"
+  default     = "_cdbb2f322a273066b96e5b0de517fed0.mhbtsbpdnt.acm-validations.aws"
+}
+
+variable "cf_s3_origin_ttl" {
+  description = "TTL for the CloudFront to S3 origin records"
+  default     = "604800"
+}


### PR DESCRIPTION
This commit brings the CNAME DNS records for the CloudFront S3 origin under Terraform management. Also, updates terraform/dns_records to use variables instead of hard-coded values.