### PR TITLE
Changes Terraform config to blue environment

### DIFF
--- a/terraform/blue/main.tf
+++ b/terraform/blue/main.tf
@@ -16,55 +16,57 @@ data "aws_availability_zones" "available" {
 }
 
 ###########################################
-# Resource - VPC and Subnets
+# Network Configuration
 ###########################################
 
 resource "aws_vpc" "main" {
   assign_generated_ipv6_cidr_block = true
   cidr_block                       = var.vpc_cidr
+  enable_dns_hostnames             = true
   tags = {
     Name = "${var.name_prefix}-vpc"
   }
 }
 
-############# Public Subnets #############
+# ############# Public Subnets #############
+# Needed for Bastion Host only
 
-resource "aws_subnet" "public1" {
-  vpc_id                                         = aws_vpc.main.id
-  availability_zone                              = data.aws_availability_zones.available.names[0]
-  assign_ipv6_address_on_creation                = true
-  enable_resource_name_dns_aaaa_record_on_launch = true
-  enable_dns64                                   = true
-  ipv6_cidr_block                                = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, 0)
-  cidr_block                                     = cidrsubnet(var.vpc_cidr, 4, 0)
-  tags = {
-    Name = "${var.name_prefix}-public-1"
-  }
-}
-resource "aws_subnet" "public2" {
-  vpc_id                                         = aws_vpc.main.id
-  availability_zone                              = data.aws_availability_zones.available.names[1]
-  assign_ipv6_address_on_creation                = true
-  enable_resource_name_dns_aaaa_record_on_launch = true
-  enable_dns64                                   = true
-  ipv6_cidr_block                                = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, 1)
-  cidr_block                                     = cidrsubnet(var.vpc_cidr, 4, 1)
-  tags = {
-    Name = "${var.name_prefix}-public-2"
-  }
-}
-resource "aws_subnet" "public3" {
-  vpc_id                                         = aws_vpc.main.id
-  availability_zone                              = data.aws_availability_zones.available.names[2]
-  assign_ipv6_address_on_creation                = true
-  enable_resource_name_dns_aaaa_record_on_launch = true
-  enable_dns64                                   = true
-  ipv6_cidr_block                                = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, 2)
-  cidr_block                                     = cidrsubnet(var.vpc_cidr, 4, 2)
-  tags = {
-    Name = "${var.name_prefix}-public-3"
-  }
-}
+# resource "aws_subnet" "public1" {
+#   vpc_id                                         = aws_vpc.main.id
+#   availability_zone                              = data.aws_availability_zones.available.names[0]
+#   assign_ipv6_address_on_creation                = true
+#   enable_resource_name_dns_aaaa_record_on_launch = true
+#   enable_dns64                                   = true
+#   ipv6_cidr_block                                = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, 0)
+#   cidr_block                                     = cidrsubnet(var.vpc_cidr, 4, 0)
+#   tags = {
+#     Name = "${var.name_prefix}-public-1"
+#   }
+# }
+# resource "aws_subnet" "public2" {
+#   vpc_id                                         = aws_vpc.main.id
+#   availability_zone                              = data.aws_availability_zones.available.names[1]
+#   assign_ipv6_address_on_creation                = true
+#   enable_resource_name_dns_aaaa_record_on_launch = true
+#   enable_dns64                                   = true
+#   ipv6_cidr_block                                = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, 1)
+#   cidr_block                                     = cidrsubnet(var.vpc_cidr, 4, 1)
+#   tags = {
+#     Name = "${var.name_prefix}-public-2"
+#   }
+# }
+# resource "aws_subnet" "public3" {
+#   vpc_id                                         = aws_vpc.main.id
+#   availability_zone                              = data.aws_availability_zones.available.names[2]
+#   assign_ipv6_address_on_creation                = true
+#   enable_resource_name_dns_aaaa_record_on_launch = true
+#   enable_dns64                                   = true
+#   ipv6_cidr_block                                = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, 2)
+#   cidr_block                                     = cidrsubnet(var.vpc_cidr, 4, 2)
+#   tags = {
+#     Name = "${var.name_prefix}-public-3"
+#   }
+# }
 
 ############# Private Subnets #############
 
@@ -100,50 +102,50 @@ resource "aws_subnet" "private3" {
 # IGW and Public Route Table
 ###########################################
 
-resource "aws_internet_gateway" "gw" {
-  vpc_id = aws_vpc.main.id
-  tags = {
-    Name = "${var.name_prefix}-igw"
-  }
-}
+# resource "aws_internet_gateway" "gw" {
+#   vpc_id = aws_vpc.main.id
+#   tags = {
+#     Name = "${var.name_prefix}-igw"
+#   }
+# }
 
 ############ Public Route Table ############
 
-resource "aws_route_table" "public" {
-  vpc_id = aws_vpc.main.id
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.gw.id
-  }
-  route {
-    ipv6_cidr_block = "::/0"
-    gateway_id      = aws_internet_gateway.gw.id
-  }
-  tags = {
-    Name = "${var.name_prefix}-public-rt"
-  }
-}
+# resource "aws_route_table" "public" {
+#   vpc_id = aws_vpc.main.id
+#   route {
+#     cidr_block = "0.0.0.0/0"
+#     gateway_id = aws_internet_gateway.gw.id
+#   }
+#   route {
+#     ipv6_cidr_block = "::/0"
+#     gateway_id      = aws_internet_gateway.gw.id
+#   }
+#   tags = {
+#     Name = "${var.name_prefix}-public-rt"
+#   }
+# }
 
 ########## Route Table Associations ##########
 
-resource "aws_route_table_association" "public1" {
-  subnet_id      = aws_subnet.public1.id
-  route_table_id = aws_route_table.public.id
-}
-resource "aws_route_table_association" "public2" {
-  subnet_id      = aws_subnet.public2.id
-  route_table_id = aws_route_table.public.id
-}
-resource "aws_route_table_association" "public3" {
-  subnet_id      = aws_subnet.public3.id
-  route_table_id = aws_route_table.public.id
-}
+# resource "aws_route_table_association" "public1" {
+#   subnet_id      = aws_subnet.public1.id
+#   route_table_id = aws_route_table.public.id
+# }
+# resource "aws_route_table_association" "public2" {
+#   subnet_id      = aws_subnet.public2.id
+#   route_table_id = aws_route_table.public.id
+# }
+# resource "aws_route_table_association" "public3" {
+#   subnet_id      = aws_subnet.public3.id
+#   route_table_id = aws_route_table.public.id
+# }
 
-###########################################
-# VPC Endpoint and Private Route Table
-###########################################
 
-########## VPC Endpoint ##########
+############ Network Connections ############
+
+########## VPC Endpoint ########## 
+## For application access to S3 ##
 
 resource "aws_vpc_endpoint" "bucket_endpoint" {
   service_name = "com.amazonaws.${var.aws_region}.s3"
@@ -156,16 +158,14 @@ resource "aws_vpc_endpoint" "bucket_endpoint" {
   }
 }
 
-########## Private Route Table ##########
+########## Private Route Table & Associations ##########
 
 resource "aws_route_table" "private" {
   vpc_id = aws_vpc.main.id
   tags = {
     Name = "${var.name_prefix}-private-rt"
   }
-
 }
-########## Route Table Associations ##########
 
 resource "aws_route_table_association" "private1" {
   subnet_id      = aws_subnet.private1.id
@@ -178,6 +178,46 @@ resource "aws_route_table_association" "private2" {
 resource "aws_route_table_association" "private3" {
   subnet_id      = aws_subnet.private3.id
   route_table_id = aws_route_table.private.id
+}
+
+###########################################
+# API Gateway
+###########################################
+
+resource "aws_apigatewayv2_api" "lyria" {
+  name          = "${var.name_prefix}-api"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_vpc_link" "lyria" {
+  name               = "${var.name_prefix}-vpc-link"
+  security_group_ids = [aws_security_group.elb_sg.id]
+  subnet_ids = [
+    aws_subnet.private1.id,
+    aws_subnet.private2.id,
+    aws_subnet.private3.id
+  ]
+}
+
+resource "aws_apigatewayv2_route" "lyria" {
+  api_id    = aws_apigatewayv2_api.lyria.id
+  route_key = "GET /{proxy+}"
+  target    = "integrations/${aws_apigatewayv2_integration.lyria.id}"
+}
+
+resource "aws_apigatewayv2_integration" "lyria" {
+  api_id             = aws_apigatewayv2_api.lyria.id
+  integration_type   = "HTTP_PROXY"
+  integration_method = "GET"
+  integration_uri    = aws_lb_listener.http.arn
+  connection_type    = "VPC_LINK"
+  connection_id      = aws_apigatewayv2_vpc_link.lyria.id
+}
+
+resource "aws_apigatewayv2_stage" "lyria" {
+  api_id      = aws_apigatewayv2_api.lyria.id
+  name        = "$default"
+  auto_deploy = true
 }
 
 ###########################################
@@ -254,12 +294,13 @@ resource "aws_autoscaling_policy" "main" {
 
 resource "aws_lb" "elb" {
   name            = "${var.name_prefix}-elb"
+  internal        = true
   security_groups = [aws_security_group.elb_sg.id]
   ip_address_type = "dualstack"
   subnets = [
-    aws_subnet.public1.id,
-    aws_subnet.public2.id,
-    aws_subnet.public3.id
+    aws_subnet.private1.id,
+    aws_subnet.private2.id,
+    aws_subnet.private3.id
   ]
   access_logs {
     bucket  = "lyria-logs"
@@ -273,10 +314,10 @@ resource "aws_lb_target_group" "lb_tg" {
   protocol = "HTTP"
   vpc_id   = aws_vpc.main.id
   health_check {
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-    timeout             = 3
-    interval            = 30
+    healthy_threshold   = 5
+    unhealthy_threshold = 5
+    timeout             = 5
+    interval            = 100
     path                = "/"
     port                = "traffic-port"
   }
@@ -285,6 +326,7 @@ resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.elb.arn
   port              = 80
   protocol          = "HTTP"
+  # Add the blocks below when ready for certificate
   #   default_action {
   #     type = "redirect"
   #     redirect {
@@ -345,7 +387,7 @@ resource "aws_lb_listener" "http" {
 
 resource "aws_security_group" "asg_elb_access_sg" {
   name        = "${var.name_prefix}_asg_elb_access_sg"
-  description = "Allow HTTP access from load balancer"
+  description = "Allow HTTP access from load balancer to Autoscaling Group"
   vpc_id      = aws_vpc.main.id
   ingress {
     description     = "Allow HTTP from Load Balancer"
@@ -360,13 +402,6 @@ resource "aws_security_group" "asg_elb_access_sg" {
     to_port         = 443
     protocol        = "tcp"
     security_groups = [aws_security_group.elb_sg.id]
-  }
-  egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
   }
 }
 
@@ -417,35 +452,27 @@ resource "aws_security_group" "bastion_sg" {
 
 resource "aws_security_group" "elb_sg" {
   name        = "${var.name_prefix}_elb_sg"
-  description = "Allow HTTP access from anywhere"
+  description = "Allow all access"
   vpc_id      = aws_vpc.main.id
 }
-resource "aws_security_group_rule" "allow_ipv6_http" {
-  type              = "ingress"
-  security_group_id = aws_security_group.elb_sg.id
-  description       = "Allow HTTP from anywhere ipv6"
-  ipv6_cidr_blocks  = ["::/0"]
-  from_port         = 80
-  to_port           = 80
-  protocol          = "tcp"
+
+resource "aws_security_group_rule" "local" {
+  security_group_id        = aws_security_group.elb_sg.id
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  source_security_group_id = aws_security_group.elb_sg.id
 }
-resource "aws_security_group_rule" "allow_ipv6_https" {
-  type              = "ingress"
+
+resource "aws_security_group_rule" "outbound" {
   security_group_id = aws_security_group.elb_sg.id
-  description       = "Allow HTTPS from anywhere ipv6"
-  ipv6_cidr_blocks  = ["::/0"]
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-}
-resource "aws_security_group_rule" "allow_ipv6" {
   type              = "egress"
-  security_group_id = aws_security_group.elb_sg.id
-  description       = "Allow all traffic to anywhere ipv6"
-  ipv6_cidr_blocks  = ["::/0"]
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
 }
 
 #############################################

--- a/terraform/blue/outputs.tf
+++ b/terraform/blue/outputs.tf
@@ -2,3 +2,8 @@ output "elb_dns_name" {
   description = "DNS name of the ELB"
   value       = aws_lb.elb.dns_name
 }
+
+output "api_endpoint" {
+  description = "API endpoint"
+  value       = aws_apigatewayv2_api.lyria.api_endpoint
+}

--- a/terraform/blue/outputs.tf
+++ b/terraform/blue/outputs.tf
@@ -7,3 +7,13 @@ output "api_endpoint" {
   description = "API endpoint"
   value       = aws_apigatewayv2_api.lyria.api_endpoint
 }
+
+output "cloudfront_url" {
+  description = "Cloudfront URL for the main site"
+  value       = aws_cloudfront_distribution.api.domain_name
+}
+
+output "cloudfront_zone_id" {
+  description = "Cloudfront zone ID for main site"
+  value       = aws_cloudfront_distribution.api.hosted_zone_id
+}

--- a/terraform/blue/variables.tf
+++ b/terraform/blue/variables.tf
@@ -26,7 +26,7 @@ variable "aws_region" {
 
 variable "vpc_cidr" {
   description = "CIDR block for VPC"
-  default     = "10.1.0.0/16"
+  default     = "10.2.0.0/16"
 }
 
 variable "name_prefix" {
@@ -44,8 +44,8 @@ variable "instance_type" {
 }
 
 variable "ami_main" {
-  description = "lyria-ipv6-test"
-  default     = "ami-0ca50cace18857643"
+  description = "lyria_v6"
+  default     = "ami-075192fbf30ebb487"
 }
 
 variable "ami_bastion" {

--- a/terraform/blue/variables.tf
+++ b/terraform/blue/variables.tf
@@ -76,12 +76,17 @@ variable "bucket_arn" {
 #### Certificate
 ####################################################
 
-variable "certificate_arn" {
-  description = "ARN of the ACM certificate"
+variable "elb_certificate_arn" {
+  description = "ARN of the ACM certificate for the ELB"
   default     = "arn:aws:acm:us-east-2:835656321421:certificate/7aee737d-0e1f-4311-b1ff-c3b596d85168"
 }
 
 variable "ssl_policy" {
   description = "SSL policy for the load balancer"
-  default     = "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
+  default     = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+}
+
+variable "cf_certificate_arn" {
+  description = "ARN of the ACM certificate for CloudFront"
+  default     = "arn:aws:acm:us-east-1:835656321421:certificate/c4c8a8b4-21e2-4fac-b136-f15debdba683"
 }

--- a/terraform/dns_records/main.tf
+++ b/terraform/dns_records/main.tf
@@ -4,33 +4,52 @@ provider "aws" {
 }
 
 
-#######################################
-# Records for ELB
-#######################################
+##############################################
+# Records for CloudFront to API for Main Site
+##############################################
 
-data "aws_lb" "current" {
-  name = "${var.name_prefix}-elb"
-}
-resource "aws_route53_record" "main" {
+resource "aws_route53_record" "main_A" {
   zone_id = var.zone_id_main
-  name    = var.A_record_name
+  name    = var.record_name
   type    = "A"
 
   alias {
-    name                   = data.aws_lb.current.dns_name
-    zone_id                = data.aws_lb.current.zone_id
+    name                   = var.cf_dns_site
+    zone_id                = var.cf_zone_id
+    evaluate_target_health = true
+  }
+}
+resource "aws_route53_record" "main_AAAA" {
+  zone_id = var.zone_id_main
+  name    = var.record_name
+  type    = "AAAA"
+
+  alias {
+    name                   = var.cf_dns_site
+    zone_id                = var.cf_zone_id
     evaluate_target_health = true
   }
 }
 
-resource "aws_route53_record" "misspelled" {
+resource "aws_route53_record" "misspelled_A" {
   zone_id = var.zone_id_misspelled
-  name    = var.A_record_name_misspelled
+  name    = var.record_name_misspelled
   type    = "A"
 
   alias {
-    name                   = data.aws_lb.current.dns_name
-    zone_id                = data.aws_lb.current.zone_id
+    name                   = var.cf_dns_site
+    zone_id                = var.cf_zone_id
+    evaluate_target_health = true
+  }
+}
+resource "aws_route53_record" "misspelled_AAAA" {
+  zone_id = var.zone_id_misspelled
+  name    = var.record_name_misspelled
+  type    = "AAAA"
+
+  alias {
+    name                   = var.cf_dns_site
+    zone_id                = var.cf_zone_id
     evaluate_target_health = true
   }
 }
@@ -53,15 +72,4 @@ resource "aws_route53_record" "cf_s3_origin_misspelled" {
   type    = "CNAME"
   records = [var.cf_s3_origin_misspelled_record]
   ttl     = var.cf_s3_origin_ttl
-}
-
-#######################################
-# Outputs
-#######################################
-
-output "elb_dns" {
-  value = data.aws_lb.current.dns_name
-}
-output "elb_zone_id" {
-  value = data.aws_lb.current.zone_id
 }

--- a/terraform/dns_records/variables.tf
+++ b/terraform/dns_records/variables.tf
@@ -1,8 +1,3 @@
-variable "name_prefix" {
-  description = "Naming prefix of current elb"
-  default     = "lyria-green"
-}
-
 variable "zone_id_main" {
   description = "Route53 zone ID for main domain"
   default     = "Z09206903VMHX9SR3PGQF"
@@ -13,12 +8,12 @@ variable "zone_id_misspelled" {
   default     = "Z06032811HZJPQ3EPMZ6P"
 }
 
-variable "A_record_name" {
+variable "record_name" {
   description = "Name of the A record"
   default     = "meettheafflerbaughs.com"
 }
 
-variable "A_record_name_misspelled" {
+variable "record_name_misspelled" {
   description = "Name of the A record for the misspelled domain"
   default     = "meetheafflerbaughs.com"
 }
@@ -46,4 +41,18 @@ variable "cf_s3_origin_misspelled_record" {
 variable "cf_s3_origin_ttl" {
   description = "TTL for the CloudFront to S3 origin records"
   default     = "604800"
+}
+
+############################################
+# For Use with CloudFront to API Gateway
+############################################
+
+variable "cf_dns_site" {
+  description = "Name of the CloudFront distribution for the site"
+  default     = "d1a5dru8p9s3s4.cloudfront.net"
+}
+
+variable "cf_zone_id" {
+  description = "Zone ID for the CloudFront distribution for the site"
+  default     = "Z2FDTNDATAQYW2"
 }

--- a/terraform/green/main.tf
+++ b/terraform/green/main.tf
@@ -3,7 +3,7 @@
 #####################################
 
 provider "aws" {
-  # profile = "admin-profile"
+  profile = "admin-profile"
   region  = var.aws_region
 }
 

--- a/terraform/green/providers.tf
+++ b/terraform/green/providers.tf
@@ -11,6 +11,6 @@ terraform {
     dynamodb_table = "lyria-state-locks"
     key            = "green/terraform.tfstate"
     region         = "us-east-2"
-    # profile        = "admin-profile"
+    profile        = "admin-profile"
   }
 }


### PR DESCRIPTION
Changes Terraform config to blue environment
    
This commit successfully modifies the configuration to not use any public IPv4 addresses. It utilizes an internal load balancer routing to an autoscaling group, both in private subnets. A VPC link is used for ALB connection to an API, which also routes to a CloudFront distribution. The CloudFront distribution has been added to the Route53 DNS records (A and AAAA). Confirmed to work and green environment has been destroyed.