### PR TITLE
Uses variables for domain aliases and policy IDs

### DIFF
--- a/terraform/blue/main.tf
+++ b/terraform/blue/main.tf
@@ -499,13 +499,8 @@ resource "aws_cloudfront_distribution" "api" {
   enabled         = true
   is_ipv6_enabled = true
   comment         = "Caches main Lyria site from API"
-  aliases = [
-    "www.meettheafflerbaughs.com",
-    "meettheafflerbaughs.com",
-    "www.meetheafflerbaughs.com",
-    "meetheafflerbaughs.com"
-  ]
-  http_version = "http2and3"
+  aliases         = var.domain_aliases
+  http_version    = "http2and3"
   tags = {
     Name    = "${var.name_prefix}-cloudfront-dist"
     Project = "Lyria"
@@ -526,8 +521,8 @@ resource "aws_cloudfront_distribution" "api" {
     allowed_methods          = ["GET", "HEAD"]
     cached_methods           = ["GET", "HEAD"]
     compress                 = true
-    cache_policy_id          = "658327ea-f89d-4fab-a63d-7e88639e58f6" # CachingOptimized
-    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader
+    cache_policy_id          = var.cache_policy_id
+    origin_request_policy_id = var.origin_request_policy_id
     target_origin_id         = "api"
   }
   viewer_certificate {

--- a/terraform/blue/variables.tf
+++ b/terraform/blue/variables.tf
@@ -90,3 +90,24 @@ variable "cf_certificate_arn" {
   description = "ARN of the ACM certificate for CloudFront"
   default     = "arn:aws:acm:us-east-1:835656321421:certificate/150d0e5f-766e-4c68-9b25-944d8fb364fc"
 }
+
+variable "domain_aliases" {
+  type        = list(string)
+  description = "Domain aliases for the CloudFront distribution/SSL certificate"
+  default = [
+    "meettheafflerbaughs.com",
+    "www.meettheafflerbaughs.com",
+    "meetheafflerbaughs.com",
+    "www.meetheafflerbaughs.com",
+  ]
+}
+
+variable "cache_policy_id" {
+  description = "ID of the cache policy for CloudFront"
+  default     = "658327ea-f89d-4fab-a63d-7e88639e58f6" # CachingOptimized
+}
+
+variable "origin_request_policy_id" {
+  description = "ID of the origin request policy for CloudFront"
+  default     = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader
+}


### PR DESCRIPTION
Moves the some CloudFront configurations to use variables instead of hardcoded values, including domain_aliases, cache_policy_id, and origin_request_policy_id.