### PR TITLE
Updates to AMI that uses DynamoDB for song order

### DIFF
--- a/hooks/configure_song_order.py
+++ b/hooks/configure_song_order.py
@@ -4,6 +4,7 @@ Script will prompt for the song order. Separate indexes by comma and press enter
 '''
 
 import boto3
+from invalidate_cache import invalidate_cloudfront_cache
 
 session = boto3.Session(profile_name='kris84')
 
@@ -39,6 +40,9 @@ if proceed == 'y':
         }
     )
     print("Song order updated.")
+
+    invalidate_cloudfront_cache('E3RDP7Z44PB9L6')
+
 
 else:
     print("Song order not updated. Exiting...")

--- a/hooks/invalidate_cache.py
+++ b/hooks/invalidate_cache.py
@@ -2,10 +2,10 @@ import os
 from datetime import datetime
 import boto3
 
+
 session = boto3.Session(profile_name='kris84')
 cloudfront = session.client('cloudfront')
 ec2 = session.client('ec2')
-
 
 
 def check_instance_status(image_id):

--- a/terraform/blue/main.tf
+++ b/terraform/blue/main.tf
@@ -111,8 +111,8 @@ resource "aws_route_table_association" "public" {
 ############ Network Connections ############
 
 ########## VPC Endpoint ##########
-## For application access to S3 ##
 
+## For application access to S3 ##
 resource "aws_vpc_endpoint" "bucket_endpoint" {
   service_name = "com.amazonaws.${var.aws_region}.s3"
   vpc_id       = aws_vpc.main.id
@@ -121,6 +121,18 @@ resource "aws_vpc_endpoint" "bucket_endpoint" {
   ]
   tags = {
     Name = "${var.name_prefix}-bucket-endpoint"
+  }
+}
+
+## For application access to DynamoDB ##
+resource "aws_vpc_endpoint" "dynamodb_endpoint" {
+  service_name = "com.amazonaws.${var.aws_region}.dynamodb"
+  vpc_id       = aws_vpc.main.id
+  route_table_ids = [
+    aws_route_table.private.id
+  ]
+  tags = {
+    Name = "${var.name_prefix}-dynamodb-endpoint"
   }
 }
 
@@ -441,7 +453,16 @@ resource "aws_iam_role_policy" "policy" {
           var.bucket_arn,
           "${var.bucket_arn}/*"
         ]
+      },
+      {
+        "Sid" : "ScanTable",
+        "Effect" : "Allow",
+        "Action" : [
+          "dynamodb:Scan"
+        ],
+        "Resource" : "arn:aws:dynamodb:us-east-1:637423562225:table/lyria_song_order"
       }
+
     ]
   })
   role = aws_iam_role.asg_bucket_role.name

--- a/terraform/blue/variables.tf
+++ b/terraform/blue/variables.tf
@@ -48,8 +48,8 @@ variable "instance_type" {
 }
 
 variable "ami_main" {
-  description = "lyria_v7"
-  default     = "ami-0cc95c0da4eda27cc"
+  description = "lyria_v8"
+  default     = "ami-053e0799540fac857"
 }
 
 variable "ami_bastion" {

--- a/terraform/dynamodb/outputs.tf
+++ b/terraform/dynamodb/outputs.tf
@@ -1,0 +1,3 @@
+output "table_arn" {
+  value = aws_dynamodb_table.lyria_song_order.arn
+}

--- a/terraform/staging_instance/main.tf
+++ b/terraform/staging_instance/main.tf
@@ -29,6 +29,10 @@ data "aws_s3_bucket" "storage_prod" {
   bucket = "${var.name_prefix}-storage-2024-prod"
 }
 
+data "aws_dynamodb_table" "lyria_song_order" {
+  name = "${var.name_prefix}_song_order"
+}
+
 ##################################################
 # Instance Profile - allows dev bucket access
 ##################################################
@@ -52,6 +56,12 @@ resource "aws_iam_role_policy" "staging_policy" {
           "${data.aws_s3_bucket.storage_prod.arn}",
           "${data.aws_s3_bucket.storage_prod.arn}/*"
         ]
+      },
+      {
+        "Sid" : "ScanTable",
+        "Effect" : "Allow",
+        "Action" : "dynamodb:Scan",
+        "Resource" : "${data.aws_dynamodb_table.lyria_song_order.arn}"
       }
     ]
   })


### PR DESCRIPTION
Also adds a VPC endpoint for DynamoDB, and modifies configure_song_order.py to invalidate CloudFront cache after changing song order.